### PR TITLE
Autoupdate fyde packages on debian-based systems

### DIFF
--- a/cga-proxy/scripts/harden-linux.sh
+++ b/cga-proxy/scripts/harden-linux.sh
@@ -143,6 +143,9 @@ EOF
     tee -a "/etc/apt/apt.conf.d/50unattended-upgrades" <<EOF
 Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Origins-Pattern {
+        "site=downloads.fyde.com,component=main";
+};
 EOF
 
     ansible-playbook -i "localhost," \


### PR DESCRIPTION
We already do this for CentOS but just confirmed that we don't update on Debian based.

The services still need to be restarted, which is not done automatically in any case but if the VM is restarted for example it would start with the new version already. SEs are very looking forward to this feature.