### PR TITLE
Show enrollment tokens after pasting

### DIFF
--- a/cga-proxy/scripts/install-cga-connector-linux.sh
+++ b/cga-proxy/scripts/install-cga-connector-linux.sh
@@ -105,7 +105,7 @@ else
         log_entry "INFO" "Please provide required variables"
 
         while [[ -z "${CONNECTOR_TOKEN:-}" ]]; do
-            read -r -p "Paste the CloudGen Access Connector enrollment token here (hidden): " -s CONNECTOR_TOKEN
+            read -r -p "Paste the CloudGen Access Connector enrollment token: " CONNECTOR_TOKEN
             echo ""
             if [[ -z "${CONNECTOR_TOKEN:-}" ]]; then
                 log_entry "ERROR" "CloudGen Access Connector enrollment token cannot be empty"

--- a/cga-proxy/scripts/install-cga-proxy-linux.sh
+++ b/cga-proxy/scripts/install-cga-proxy-linux.sh
@@ -137,7 +137,7 @@ else
     PUBLIC_PORT=${PUBLIC_PORT:-"443"}
 
     while [[ -z "${PROXY_TOKEN:-}" ]]; do
-        read -r -p "Paste the CloudGen Access Proxy enrollment link (hidden): " -s PROXY_TOKEN
+        read -r -p "Paste the CloudGen Access Proxy enrollment token: " PROXY_TOKEN
         echo ""
         if [[ -z "${PROXY_TOKEN:-}" ]]; then
             log_entry "ERROR" "CloudGen Access Proxy enrollment link cannot be empty"


### PR DESCRIPTION
Custommers and SE's sometimes have issues with pasting the token and they cannot find the issue when the token is hidden. After this PR the token will be shown on the command line.