### PR TITLE
Fix PAM auth for hardening script

### DIFF
--- a/shared/scripts/harden-linux.sh
+++ b/shared/scripts/harden-linux.sh
@@ -187,6 +187,7 @@ tee "${TMP_DIR}"/playbook.yml <<EOF
     - ssh_hardening
     - os_hardening
   vars:
+    os_auth_pam_sssd_enable: false
     ssh_max_auth_retries: "${SSH_MAX_AUTH_RETRIES}"
     ssh_permit_root_login: "${SSH_PERMIT_ROOT_LOGIN}"
     ssh_server_password_login: ${SSH_SERVER_PASSWORD_LOGIN}


### PR DESCRIPTION
<!-- If this is not ready to be reviewed create a draft pull request -->
# Summary
<!-- Include a summary of the change and which issue is fixed -->

Fix PAM auth for hardening script

## Description
<!-- Include detailed description of the change when needed-->

Prevents sending password authentication to `sssd` (more info [here](https://linux.die.net/man/8/sssd) and [here](https://github.com/dev-sec/ansible-collection-hardening/tree/master/roles/os_hardening#variables)) to avoid manipulation errors since `sssd` is not configured.

## Type of change
<!-- These are only examples you can change these however it fits -->

- Bug fix (non-breaking change which fixes an issue)